### PR TITLE
Improve client stability

### DIFF
--- a/src/SmartHomeDotNet.Package/Mqtt/MqttBrokerConfig.cs
+++ b/src/SmartHomeDotNet.Package/Mqtt/MqttBrokerConfig.cs
@@ -19,6 +19,8 @@ namespace SmartHomeDotNet.Mqtt
 
 		public string ClientStatusTopic { get; set; } = "homeautomationengine/status";
 
+		public string ClientLastSeenTopic { get; set; } = "homeautomationengine/lastseen";
+
 		public IEnumerable<string> Validate()
 		{
 			if (Host.IsEmpty())

--- a/src/SmartHomeDotNet.Package/Mqtt/MqttCache.cs
+++ b/src/SmartHomeDotNet.Package/Mqtt/MqttCache.cs
@@ -22,7 +22,7 @@ namespace SmartHomeDotNet.Mqtt
 
 		public bool TryUpdate(string topic, string value, bool retained)
 		{
-			this.Log().Info($"Received MQTT message '{topic}': {value}");
+			this.Log().Debug($"Received MQTT message '{topic}': {value}");
 
 			return topic
 				.Split(_seperator, StringSplitOptions.RemoveEmptyEntries)


### PR DESCRIPTION
- Add active pulling (publish message each minute) that ensure the connection remains active
- Add inifnite retry of connection to avoid to keep client staying disconnected in case of network issues
- Fix possible concurrency issue that conduct topic to subscribe while Paused
- Do not flush the [Value|Child]Updated flags until the value was actually published